### PR TITLE
Add workflow to draft release on push

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -1,0 +1,29 @@
+# The overall template of the release notes
+template: |
+  Open Distro for Elasticsearch Version $RESOLVED_VERSION
+  $CHANGES
+
+# Setting the formatting and sorting for the release notes body
+name-template: Version $RESOLVED_VERSION
+change-template: "- $TITLE (PR [#$NUMBER](https://github.com/opendistro-for-elasticsearch/sql-cli/pull/$NUMBER))"
+sort-by: merged_at
+sort-direction: ascending
+
+# Organizing the tagged PRs into categories
+categories:
+  - title: "Version Upgrades"
+    labels:
+      - "version compatibility"
+  - title: "Features"
+    labels:
+      - "feature"
+  - title: "Enhancements"
+    labels:
+      - "enhancement"
+  - title: "Bug Fixes"
+    labels:
+      - "bug"
+      - "bug fix"
+  - title: "Documentation"
+    labels:
+      - "documentation"

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -1,0 +1,20 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    name: Update draft release notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update draft release notes
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: draft-release-notes-config.yml
+          tag: (None)
+          version: 1.9.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Use [release-drafter](https://github.com/release-drafter/release-drafter) to automatically create/update release draft on each push to master. Release draft will be generated from merged pr and categorized by labels. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
